### PR TITLE
Utilize correct Github raw API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 ### <img src="https://raw.githubusercontent.com/4IceG/Personal_data/master/dooffy_design_icons_EU_flags_United_Kingdom.png" height="24"> To install packages from my repository:
 - Execute following commands on your OpenWrt router:
   ```
-  grep -q IceG_repo /etc/opkg/customfeeds.conf || echo 'src/gz IceG_repo https://github.com/4IceG/Modem-extras/raw/main/myrepo' >> /etc/opkg/customfeeds.conf
-  wget https://github.com/4IceG/Modem-extras/raw/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
+  grep -q IceG_repo /etc/opkg/customfeeds.conf || echo 'src/gz IceG_repo https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo' >> /etc/opkg/customfeeds.conf
+  wget https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
   opkg-key add /tmp/IceG-repo.pub
   opkg update
 
@@ -26,7 +26,7 @@
 - OR, to do it manually:
   1. Add the following entry to the /etc/opkg/customfeeds.conf file to the OpenWrt router:
      ```
-     src/gz IceG_repo https://github.com/4IceG/Modem-extras/raw/main/myrepo
+     src/gz IceG_repo https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo
      ```
       <details>
          <summary>Show me how</summary>
@@ -37,7 +37,7 @@
       </details>
   2. Add repository public key with commands:
       ``` bash
-      wget https://github.com/4IceG/Modem-extras/raw/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
+      wget https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
       opkg-key add /tmp/IceG-repo.pub
       ```
   3. Execute command to update repositories:
@@ -53,8 +53,8 @@
 #### Metoda 1. 
 Wykonaj te polecenia na routerze z OpenWrt:
   ```
-  grep -q IceG_repo /etc/opkg/customfeeds.conf || echo 'src/gz IceG_repo https://github.com/4IceG/Modem-extras/raw/main/myrepo' >> /etc/opkg/customfeeds.conf
-  wget https://github.com/4IceG/Modem-extras/raw/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
+  grep -q IceG_repo /etc/opkg/customfeeds.conf || echo 'src/gz IceG_repo https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo' >> /etc/opkg/customfeeds.conf
+  wget https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
   opkg-key add /tmp/IceG-repo.pub
   opkg update
 
@@ -64,7 +64,7 @@ Wykonaj te polecenia na routerze z OpenWrt:
 
 Krok 1. Do routera z OpenWrt dodaj do pliku /etc/opkg/customfeeds.conf następujący wpis:
 ``` bash
-src/gz IceG_repo https://github.com/4IceG/Modem-extras/raw/main/myrepo
+src/gz IceG_repo https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo
 ```
 
 <details>
@@ -77,7 +77,7 @@ src/gz IceG_repo https://github.com/4IceG/Modem-extras/raw/main/myrepo
 
 Krok 2. Dodaj klucz publiczny repozytorium za pomoca poleceń:
 ``` bash
-wget https://github.com/4IceG/Modem-extras/raw/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
+wget https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrepo/IceG-repo.pub -O /tmp/IceG-repo.pub
 opkg-key add /tmp/IceG-repo.pub
 ```
 Krok 3. Wykonaj polecenie aktualizacji repozytoriów:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
- <a href="https://github.com/4IceG/Modem-extras"><img width=7% src="https://github.com/4IceG/Personal_data/blob/master/ipk-repo.png?raw=true"></a>
- <a href="https://github.com/4IceG/Modem-extras-apk"><img width=5% src="https://github.com/4IceG/Personal_data/blob/master/apk-repo.png?raw=true"></a>
+ <a href="https://github.com/4IceG/Modem-extras"><img width=7% src="https://raw.githubusercontent.com/4IceG/Personal_data/master/ipk-repo.png"></a>
+ <a href="https://github.com/4IceG/Modem-extras-apk"><img width=5% src="https://raw.githubusercontent.com/4IceG/Personal_data/master/apk-repo.png"></a>
 </p>
 
 # Modem-extras (My repository)
@@ -31,8 +31,8 @@
       <details>
          <summary>Show me how</summary>
          
-      ![](https://github.com/4IceG/Personal_data/blob/master/repo1.PNG?raw=true)
-      ![](https://github.com/4IceG/Personal_data/blob/master/repo2en.png?raw=true)
+      ![](https://raw.githubusercontent.com/4IceG/Personal_data/master/repo1.PNG)
+      ![](https://raw.githubusercontent.com/4IceG/Personal_data/master/repo2en.png)
       
       </details>
   2. Add repository public key with commands:
@@ -70,8 +70,8 @@ src/gz IceG_repo https://raw.githubusercontent.com/4IceG/Modem-extras/main/myrep
 <details>
    <summary>Pokaż jak to zrobić</summary>
    
-![](https://github.com/4IceG/Personal_data/blob/master/repo1.PNG?raw=true)
-![](https://github.com/4IceG/Personal_data/blob/master/repo2pl.png?raw=true)
+![](https://raw.githubusercontent.com/4IceG/Personal_data/master/repo1.PNG)
+![](https://raw.githubusercontent.com/4IceG/Personal_data/master/repo2pl.png)
 
 </details>
 
@@ -94,7 +94,7 @@ opkg install luci-app-sms-tool-js
 </p>
 <p align="center">
 <a href="https://github.com/sponsors/4IceG">
-  <img width=25% src="https://github.com/4IceG/Personal_data/blob/master/nspons.PNG?raw=true">
+  <img width=25% src="https://raw.githubusercontent.com/4IceG/Personal_data/master/nspons.PNG">
 </a>
 </p>
 


### PR DESCRIPTION
Github expects resources to be drawn from the raw api instead of from Github directly. This would lead to random opkg hangs when Github.com started throttling. Updated repo to point to the correct api, and fixed a few trailing resources as well.